### PR TITLE
MacOS: Set `as` options to cross-compile for x86_64

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,8 +6,8 @@ jobs:
   test:
     strategy:
       matrix:
-        # have to use macos-13 because newer versions are arm-based
-        os: [ubuntu-latest, macos-13]
+        # check on macos-13 (x86) and macos-latest (ARM through Rosetta)
+        os: [ubuntu-latest, macos-13, macos-latest]
 
     runs-on: ${{ matrix.os }}
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -96,12 +96,27 @@ fn output_path(
 fn assemble(options: &CliOptions, file: &Path, asm_file: OutFile) -> Result<OutFile, WreccError> {
     let output_path = output_path(file, &options.output_path, options.no_link, "o");
 
-    let output = Command::new("as")
-        .arg(asm_file.get())
-        .arg("-o")
-        .arg(output_path.get())
-        .output()
-        .map_err(|_| WreccError::Sys("could not invoke assembler 'as'".to_string()))?;
+    let output = match std::env::consts::OS {
+        "linux" => {
+            Command::new("as")
+            .arg(asm_file.get())
+            .arg("-o")
+            .arg(output_path.get())
+            .output()
+            .map_err(|_| WreccError::Sys("could not invoke assembler 'as'".to_string()))?
+        }
+        "macos" => {
+            Command::new("as")
+            .arg(asm_file.get())
+            .arg("-o")
+            .arg(output_path.get())
+            .arg("-arch")
+            .arg("x86_64")
+            .output()
+            .map_err(|_| WreccError::Sys("could not invoke assembler 'as'".to_string()))?
+        }
+        _ => return Err(WreccError::Sys(String::from("only supports linux and macos"))),
+    };
 
     if output.status.success() {
         Ok(output_path)


### PR DESCRIPTION
This makes wrecc work on Apple silicon systems, and the resulting binary can be transparently run with Rosetta. Does nothing on Linux or Mac OS on x86_64.