### PR TITLE
Add #error preprocessor directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ cargo install wrecc
 ## Features
 Since not all keywords are currently implemented wrecc uses [custom standard-headers](https://github.com/PhilippRados/wrecc/tree/master/include) which are built directly into the binary
 ### Preprocessor
-The preprocessor implements all [C99 preprocessor directives](https://en.cppreference.com/w/c/keyword), except `#line`, `#error` and `#pragma`. Most prominently it currently also misses function-like macros which are on the agenda though.
+The preprocessor implements all [C99 preprocessor directives](https://en.cppreference.com/w/c/keyword), except `#line` and `#pragma`. Most prominently it currently also misses function-like macros which are on the agenda though.
 
 ### Compiler
 #### Supported Keywords <a name="keywords"></a>

--- a/tests/fixtures/error_pragma.c
+++ b/tests/fixtures/error_pragma.c
@@ -1,0 +1,4 @@
+int main() {
+    return 42;
+#error oh   nooooo
+}

--- a/tests/snapshots/success_const_err
+++ b/tests/snapshots/success_const_err
@@ -3,7 +3,7 @@ error: cannot assign variable which was declared 'const'
 |
 16   a.dig = Two;
 |          ^
-error: cannot assign to 'struct Foo' that contains member 'dig' declared 'const'
+error: cannot assign to 'struct Foo' that contains member 'dig' declared 'const'
 |  --> in tests/fixtures/const_err.c:17:5
 |
 17   a = b;

--- a/tests/snapshots/success_error_pragma
+++ b/tests/snapshots/success_error_pragma
@@ -1,0 +1,6 @@
+error: oh   nooooo
+|  --> in tests/fixtures/error_pragma.c:3:2
+|
+3 #error oh   nooooo
+|  ^
+1 error generated.

--- a/wrecc_compiler/src/compiler/common/error.rs
+++ b/wrecc_compiler/src/compiler/common/error.rs
@@ -154,6 +154,7 @@ pub enum ErrorKind {
     ElifAfterElse,
     TrailingTokens(&'static str),
     MaxIncludeDepth(usize),
+    ErrorDirective(String),
 
     Regular(&'static str), // generic error message when message only used once
     Multiple(Vec<Error>),
@@ -226,7 +227,7 @@ impl ErrorKind {
             }
             ErrorKind::IncompleteFuncParam(func_name, qtype) => {
                 format!(
-                    "function '{}' contains incomplete type '{}' as parameter",
+                    "function '{}' contains incomplete type '{}' as parameter",
                     func_name, qtype
                 )
             }
@@ -235,7 +236,7 @@ impl ErrorKind {
                     .to_string()
             }
             ErrorKind::TypeAlreadyExists(name, token) => {
-                format!("type '{}' already exists but not as {}", name, token)
+                format!("type '{}' already exists but not as {}", name, token)
             }
             ErrorKind::EnumForwardDecl => "cannot forward declare enums".to_string(),
             ErrorKind::EmptyAggregate(token) => {
@@ -275,7 +276,7 @@ impl ErrorKind {
             ErrorKind::ConstAssign => "cannot assign variable which was declared 'const'".to_string(),
             ErrorKind::ConstStructAssign(ty, member) => {
                 format!(
-                    "cannot assign to '{}' that contains member '{}' declared 'const'",
+                    "cannot assign to '{}' that contains member '{}' declared 'const'",
                     ty, member
                 )
             }
@@ -478,6 +479,7 @@ impl ErrorKind {
             ErrorKind::MaxIncludeDepth(max) => {
                 format!("#include is nested too deeply, exceeds maximum-depth of {}", max)
             }
+            ErrorKind::ErrorDirective(s) => s.clone(),
 
             ErrorKind::Regular(s) => s.to_string(),
             ErrorKind::Multiple(_) => {

--- a/wrecc_compiler/src/compiler/scanner.rs
+++ b/wrecc_compiler/src/compiler/scanner.rs
@@ -239,6 +239,7 @@ impl<'a> Scanner<'a> {
                 | PPKind::Else
                 | PPKind::Elif
                 | PPKind::Endif
+                | PPKind::Error
                 | PPKind::Undef
                 | PPKind::Define
                 | PPKind::Defined => {

--- a/wrecc_compiler/src/preprocessor/mod.rs
+++ b/wrecc_compiler/src/preprocessor/mod.rs
@@ -639,6 +639,18 @@ impl<'a> Preprocessor<'a> {
                                 }
                                 self.conditional_block(directive)
                             }
+                            TokenKind::Error => {
+                                let _ = self.skip_whitespace();
+                                let rest = self
+                                    .fold_until_token(TokenKind::Newline)
+                                    .into_iter()
+                                    .map(|t| t.kind.to_string())
+                                    .collect::<String>();
+                                Err(Error::new(
+                                    &PPToken::from(&directive, self.filename),
+                                    ErrorKind::ErrorDirective(rest),
+                                ))
+                            }
                             _ => Err(Error::new(
                                 &PPToken::from(&directive, self.filename),
                                 ErrorKind::InvalidDirective(directive.kind.to_string()),

--- a/wrecc_compiler/src/preprocessor/scanner.rs
+++ b/wrecc_compiler/src/preprocessor/scanner.rs
@@ -21,6 +21,7 @@ pub enum TokenKind {
     Else,
     Endif,
     Newline,
+    Error,
     String(String),
     CharLit(String),
     Ident(String),
@@ -52,7 +53,7 @@ impl Token {
             TokenKind::Hash | TokenKind::Other(_) => 1,
             TokenKind::If => 2,
             TokenKind::Else | TokenKind::Elif => 4,
-            TokenKind::Undef | TokenKind::Ifdef | TokenKind::Endif => 5,
+            TokenKind::Undef | TokenKind::Ifdef | TokenKind::Endif | TokenKind::Error => 5,
             TokenKind::Define | TokenKind::Ifndef => 6,
             TokenKind::Include | TokenKind::Defined => 7,
             TokenKind::String(s)
@@ -77,7 +78,8 @@ impl TokenKind {
             | TokenKind::If
             | TokenKind::Elif
             | TokenKind::Else
-            | TokenKind::Endif => Some(self.to_string()),
+            | TokenKind::Endif
+            | TokenKind::Error => Some(self.to_string()),
             _ => None,
         }
     }
@@ -96,6 +98,7 @@ impl ToString for TokenKind {
             TokenKind::Elif => "elif".to_string(),
             TokenKind::Else => "else".to_string(),
             TokenKind::Endif => "endif".to_string(),
+            TokenKind::Error => "error".to_string(),
             TokenKind::Newline => "\n".to_string(),
             TokenKind::String(s)
             | TokenKind::CharLit(s)
@@ -140,6 +143,7 @@ impl Scanner {
                 ("elif", TokenKind::Elif),
                 ("else", TokenKind::Else),
                 ("endif", TokenKind::Endif),
+                ("error", TokenKind::Error),
             ]),
         }
     }


### PR DESCRIPTION
I've also replaced some non-breaking spaces in a couple of error messages with regular spaces, just because it looked like they're accidental, and they were near the change I was making. Happy to split that part of the change into a separate PR, or remove it altogether if using nbsps was intended.